### PR TITLE
corrupt file fix

### DIFF
--- a/server/asp_net/Handler.ashx
+++ b/server/asp_net/Handler.ashx
@@ -268,7 +268,8 @@ public class Handler : IHttpAsyncHandler
                     {
                         using (Stream FileStreamWriter = new FileStream(FileName, FileMode.CreateNew, FileAccess.Write))
                         {
-                            FromStreamToStream(context.Request.InputStream, FileStreamWriter);
+                            var inputStream = context.Request.Files.Get(0).InputStream;
+                            FromStreamToStream(inputStream, FileStreamWriter);
                         }
                     }
                     catch (Exception exception)


### PR DESCRIPTION
Was producing corrupt file because it was trying to write the entire request into a file which leads to the file being corrupt.
